### PR TITLE
dont let build.sh run as root

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #! /bin/bash
 
+# Are we root? Fail if so
+[ $UID -eq 0 ] && echo "Please don't run this script as root...terminating" && exit 1
+
 # Update repo, overwriting local changes
 git fetch --all
 git reset --hard origin/master


### PR DESCRIPTION
The server that this site runs on in production doesn't run as root, and there is no real reason to build this site as root anyway, so lets make the build.sh script fail if your uid is 0!