### PR TITLE
Update home, add weeks 1 and 2 for fall

### DIFF
--- a/content/events/2017/fall2017/20170926_wk1.mkd
+++ b/content/events/2017/fall2017/20170926_wk1.mkd
@@ -1,0 +1,18 @@
+title: Welcome to LUG and Planning
+datetime: 2017-09-26 18:00:00
+category: events
+slug: meeting20170926
+preview: LUG event planning fall2017 and a bit of topical knowledge about Linux
+locations: Kelly Engineering Center 1007
+
+---
+
+LUG will meet to welcome new attendents and welcome back returning members. 
+We will discussed the Linux Kernel and GNU/Linux operating systems. The purpose
+of the Linux User's Group and it's events in general will bealso explained.
+This meeting will also to serve as a way to plan meetings in the future for
+the coming fall term. 
+
+When: 6pm
+
+Where: Kelly Engineering Center 1007

--- a/content/events/2017/fall2017/20171003_wk2.mkd
+++ b/content/events/2017/fall2017/20171003_wk2.mkd
@@ -1,0 +1,14 @@
+title: Fall 2017 Installfest
+datetime: 2017-10-03 18:00:00
+category: events
+slug: meeting20171003
+preview: Quarterly InstallFest for fall term. Come and install Linux!
+locations: 
+
+---
+
+Content
+
+When: 6pm
+
+Where:

--- a/content/home.mkd
+++ b/content/home.mkd
@@ -16,16 +16,7 @@ pagination:
 ## Tuesday at 6:00pm at Kelley Engineering Center in KEC 1005
 
 - - - -
-
-### Upcoming Industry Event: Nordstrom
-
-LUG will be hosting Nordstrom (yes that Nordstrom) to talk about the kickass infra they use to host and run their ecommerce platforms.
-There will be two talks, an opportunity to ask about internships and their tech, and free pizza.
-It will be at the normal LUG meeting time on Tuesday May 16.
-If you can make it [RSVP to guarentee free pizza and tech swag][nordstrom]!
-
-
-### What is the Oregon State University Linux Users Group?
+### What is the Oregon State University Linux Users Group
 
 We are self described as "mostly a group of nerds. However we are not your
 normal nerds. We are a highly active and self-organizing group dedicated to
@@ -70,7 +61,6 @@ attend, no strings attached.
 
 [gh]:https://github.com/osulug/
 
-[nordstrom]: https://goo.gl/forms/mzcSMVtgitXne2Aw2
 
 [form]: https://docs.google.com/spreadsheet/viewform?formkey=dDIySHZQeHNhbFhkd25uaTFUNEZubnc6MQ
 [ircguide]: /blog/irc/


### PR DESCRIPTION
Remove nordstrom thing, touchups on home page.

Added week1 and week2 for fall events. I will get the other weeks up soon but I wanted to push the home page updates right now. 