### PR TITLE
fix 404 error vim link network.mkd

### DIFF
--- a/content/guides/network.mkd
+++ b/content/guides/network.mkd
@@ -102,7 +102,7 @@ If you have any questions, come hang out in the lug IRC room
 see [our IRC guide][irc]
 
 [ssh_howto]:http://www.wikihow.com/Use-SSH
-[putty_howto]:http://webmaster.iu.edu/tool_guide_info/webserve_putty.shtml
+[putty_howto]:https://it.engineering.oregonstate.edu/accessing-unix-server-using-putty-ssh
 [bash_howto]:http://tldp.org/HOWTO/Bash-Prog-Intro-HOWTO.html
 [vim_howto]:https://blog.interlinked.org/vi-vim-neovim
 [emacs]: http://www.gnu.org/software/emacs/tour/

--- a/content/guides/network.mkd
+++ b/content/guides/network.mkd
@@ -104,7 +104,7 @@ see [our IRC guide][irc]
 [ssh_howto]:http://www.wikihow.com/Use-SSH
 [putty_howto]:http://webmaster.iu.edu/tool_guide_info/webserve_putty.shtml
 [bash_howto]:http://tldp.org/HOWTO/Bash-Prog-Intro-HOWTO.html
-[vim_howto]:http://blog.interlinked.org/tutorials/vim_tutorial.html
+[vim_howto]:https://blog.interlinked.org/vi-vim-neovim
 [emacs]: http://www.gnu.org/software/emacs/tour/
 [nano]: http://www.nano-editor.org/docs.php
 [dns]:http://en.wikipedia.org/wiki/Domain_Name_System


### PR DESCRIPTION
[http://lug.oregonstate.edu/blog/resources/](url) 404 error on link to vim.  I think I found the tutorial this was originally linked to.

Update: Found putty link that is not linking to the intended webpage.  Suggest to link to OSU website here [https://it.engineering.oregonstate.edu/accessing-unix-server-using-putty-ssh](url)